### PR TITLE
Support bigger-height children

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,7 +37,7 @@
         "no-trailing-spaces": [2],
         "no-undef": [2],
         "no-unreachable": [2],
-        "no-unused-vars": [2, { "args": "none" }],
+        "no-unused-vars": [2, { "args": "after-used" }],
         "semi": [2, "always"],
         "space-before-function-paren": [2, {"anonymous": "always", "named": "never"} ],
         "space-before-blocks": [2, { "functions": "always" } ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,18 @@
 
 ### Breaking changes
 - Dependency on [angular-scrollie](https://github.com/joelmukuthu/angular-scrollie)
+- [`before-snap`](DOCS.md#before-snap) and [`after-snap`](DOCS.md#after-snap) are
+now only called if snapIndex changes
 
 ### Features
 - Support overriding the next snapIndex by returning a number from
 [`before-snap`](DOCS.md#before-snap)
 - Support [disabling/enabling](DOCS.md#snapscroll-directive) snapscroll
 programmatically
+
+### Fixes
+- [`snap-index`](DOCS.md#snap-index) is not initialized if the element is not
+scrollable
 
 ## 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ now only called if snapIndex changes
 [`before-snap`](DOCS.md#before-snap)
 - Support [disabling/enabling](DOCS.md#snapscroll-directive) snapscroll
 programmatically
+- Support child elements whose height is greater than the snapscroll element
 
 ### Fixes
 - [`snap-index`](DOCS.md#snap-index) is not initialized if the element is not
 scrollable
+- Ensure snapscroll never tries to set scrollTop to a value that is out of bounds
 
 ## 0.3.0
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ angular-snapscroll adds vertical scroll-and-snap functionality to angular.
 
 - JS-only implementation
 - Only requires angular core
-- 5.7kB when minified, 2.1kB when gzipped
+- 6.2kB when minified, 2.3kB when gzipped
 
 ### [Demo](http://joelmukuthu.github.io/angular-snapscroll/)
 

--- a/src/directives/snapscroll.js
+++ b/src/directives/snapscroll.js
@@ -221,11 +221,10 @@
                             return;
                         }
                         if (!isNumber(current)) {
-                            if (isNumber(previous)) {
-                                scope.snapIndex = previous;
-                            } else {
-                                scope.snapIndex = 0;
+                            if (!isNumber(previous)) {
+                                previous = 0;
                             }
+                            scope.snapIndex = previous;
                             return;
                         }
                         if (current % 1 !== 0) {

--- a/src/directives/snapscroll.js
+++ b/src/directives/snapscroll.js
@@ -477,7 +477,8 @@
                     }
 
                     function bindScroll() {
-                        if (scope.preventSnappingAfterManualScroll) {
+                        if (scope.preventSnappingAfterManualScroll ||
+                            scope.scrollBound) {
                             return;
                         }
                         if (angular.isDefined(scope.snapDirection)) { // still snapping
@@ -486,10 +487,15 @@
                             return;
                         }
                         element.on('scroll', onScroll);
+                        scope.scrollBound = true;
                     }
 
                     function unbindScroll() {
+                        if (!scope.scrollBound) {
+                            return;
+                        }
                         element.off('scroll', onScroll);
+                        scope.scrollBound = false;
                     }
 
                     function bindScrollAfterDelay() {

--- a/src/directives/snapscroll.js
+++ b/src/directives/snapscroll.js
@@ -56,22 +56,17 @@
                         return getHeight(element[0]);
                     }
 
-                    function getScrollTop(snapIndex) {
-                        var children = getChildren();
+                    function getScrollTop(innerSnapIndex, snapIndex) {
                         var scrollTop = 0;
+                        var children = getChildren();
                         for (var i = 0; i < snapIndex; i++) {
                             scrollTop += getHeight(children[i]);
                         }
-                        return scrollTop;
-                    }
-
-                    function getInnerScrollTop(innerSnapIndex, snapIndex) {
-                        var scrollTop = getScrollTop(snapIndex);
                         if (innerSnapIndex === 0) {
                             return scrollTop;
                         }
                         var snapHeight = getSnapHeight();
-                        var childHeight = getChildHeight(snapIndex);
+                        var childHeight = getHeight(children[snapIndex]);
                         var innerScrollTop;
                         if (angular.isDefined(scope.previousInnerSnapIndex) &&
                             innerSnapIndex < scope.previousInnerSnapIndex) {
@@ -81,7 +76,7 @@
                             }
                         } else {
                             innerScrollTop = 0;
-                            for (var i = 0; i < innerSnapIndex; i++) {
+                            for (var k = 0; k < innerSnapIndex; k++) {
                                 innerScrollTop += snapHeight;
                             }
                             var overflow = innerScrollTop + snapHeight - childHeight;
@@ -129,10 +124,7 @@
                     }
 
                     function snapTo(innerSnapIndex, snapIndex) {
-                        var scrollTop = getInnerScrollTop(
-                            innerSnapIndex,
-                            snapIndex
-                        );
+                        var scrollTop = getScrollTop(innerSnapIndex, snapIndex);
                         var args;
                         if (!scope.snapAnimation) {
                             args = [
@@ -308,8 +300,8 @@
                             newInnerSnapIndex = 0;
                             newSnapIndex = scope.snapIndex + 1;
                         }
-                        if (angular.isDefined(newInnerSnapIndex)
-                            && angular.isDefined(newSnapIndex)) {
+                        if (angular.isDefined(newInnerSnapIndex) &&
+                            angular.isDefined(newSnapIndex)) {
                             updateIndeces(newInnerSnapIndex, newSnapIndex);
                             return;
                         }

--- a/src/directives/snapscroll.js
+++ b/src/directives/snapscroll.js
@@ -1,4 +1,13 @@
 (function () {
+    function isNumber(value) {
+        return angular.isNumber(value) && !isNaN(value);
+    }
+
+    var isDefined = angular.isDefined;
+    var isUndefined = angular.isUndefined;
+    var isFunction = angular.isFunction;
+    var forEach = angular.forEach;
+
     var scopeObject = {
         enabled: '=snapscroll',
         snapIndex: '=?',
@@ -36,10 +45,6 @@
                 scope: scopeObject,
                 controller: controller,
                 link: function (scope, element, attributes) {
-                    function isNumber(value) {
-                        return angular.isNumber(value) && !isNaN(value);
-                    }
-
                     function getChildren() {
                         return element.children();
                     }
@@ -85,7 +90,7 @@
                         var snapHeight = getSnapHeight();
                         var childHeight = getHeight(children[snapIndex]);
                         var innerScrollTop;
-                        if (angular.isDefined(previousCompositeIndex) &&
+                        if (isDefined(previousCompositeIndex) &&
                             innerSnapIndex < previousCompositeIndex[1]) {
                             innerScrollTop = childHeight;
                             for (var j = innerSnapIndex; j >= 0; j--) {
@@ -107,14 +112,14 @@
 
                     function snapTo(compositeIndex, previousCompositeIndex) {
                         var snapIndex = compositeIndex[0];
-                        var isSnapIndexChanged = angular.isUndefined(previousCompositeIndex) ||
+                        var isSnapIndexChanged = isUndefined(previousCompositeIndex) ||
                             snapIndex !== previousCompositeIndex[0];
                         if (isSnapIndexChanged) {
                             var returnValue = scope.beforeSnap({
                                 snapIndex: snapIndex
                             });
                             if (returnValue === false) {
-                                if (angular.isDefined(previousCompositeIndex)) {
+                                if (isDefined(previousCompositeIndex)) {
                                     scope.ignoreCompositeIndexChange = true;
                                     scope.compositeIndex = previousCompositeIndex;
                                 }
@@ -149,7 +154,7 @@
                                 element,
                                 scrollTop
                             ];
-                        } else if (angular.isUndefined(scope.snapEasing)) {
+                        } else if (isUndefined(scope.snapEasing)) {
                             // TODO: add tests for this. Will require refactoring
                             // the default values into an object, which is a good
                             // change anyway
@@ -193,7 +198,7 @@
                             return false;
                         }
                         var totalHeight = 0;
-                        angular.forEach(children, function (child) {
+                        forEach(children, function (child) {
                             totalHeight += getHeight(child);
                         });
                         if (totalHeight < snapHeight) {
@@ -211,7 +216,7 @@
                         if (!isScrollable()) {
                             return;
                         }
-                        if (angular.isUndefined(current)) {
+                        if (isUndefined(current)) {
                             scope.snapIndex = 0;
                             return;
                         }
@@ -250,7 +255,7 @@
                     }
 
                     function unwatchSnapIndex() {
-                        if (!angular.isFunction(scope.unwatchSnapIndex)) {
+                        if (!isFunction(scope.unwatchSnapIndex)) {
                             return;
                         }
                         scope.unwatchSnapIndex();
@@ -258,7 +263,7 @@
                     }
 
                     function compositeIndexChanged(current, previous) {
-                        if (angular.isUndefined(current)) {
+                        if (isUndefined(current)) {
                             return;
                         }
                         var snapIndex = current[0];
@@ -281,7 +286,7 @@
                     }
 
                     function unwatchCompositeIndex() {
-                        if (!angular.isFunction(scope.unwatchCompositeIndex)) {
+                        if (!isFunction(scope.unwatchCompositeIndex)) {
                             return;
                         }
                         scope.unwatchCompositeIndex();
@@ -394,7 +399,7 @@
                     }
 
                     function snapHeightChanged(current, previous) {
-                        if (angular.isUndefined(current)) {
+                        if (isUndefined(current)) {
                             return;
                         }
                         if (!isNumber(current)) {
@@ -405,12 +410,12 @@
                         }
 
                         setHeight(element, current);
-                        angular.forEach(getChildren(), function (child) {
+                        forEach(getChildren(), function (child) {
                             setHeight(angular.element(child), current);
                         });
 
-                        if (angular.isDefined(scope.snapIndex)) {
-                            if (angular.isUndefined(scope.compositeIndex)) {
+                        if (isDefined(scope.snapIndex)) {
+                            if (isUndefined(scope.compositeIndex)) {
                                 scope.compositeIndex = [scope.snapIndex, 0];
                             }
                             snapTo(scope.compositeIndex);
@@ -425,7 +430,7 @@
                     }
 
                     function unwatchSnapHeight() {
-                        if (!angular.isFunction(scope.unwatchSnapHeight)) {
+                        if (!isFunction(scope.unwatchSnapHeight)) {
                             return;
                         }
                         scope.unwatchSnapHeight();
@@ -500,7 +505,7 @@
                             scope.scrollBound) {
                             return;
                         }
-                        if (angular.isDefined(scope.snapDirection)) { // still snapping
+                        if (isDefined(scope.snapDirection)) { // still snapping
                             // TODO: add tests for this
                             bindScrollAfterDelay();
                             return;
@@ -546,9 +551,9 @@
                         }
 
                         var snapEasing = attributes.snapEasing;
-                        if (angular.isDefined(snapEasing)) {
+                        if (isDefined(snapEasing)) {
                             scope.snapEasing = scope.$parent.$eval(snapEasing);
-                        } else if (angular.isFunction(defaultSnapscrollScrollEasing)) {
+                        } else if (isFunction(defaultSnapscrollScrollEasing)) {
                             scope.snapEasing = defaultSnapscrollScrollEasing;
                         }
 
@@ -559,11 +564,11 @@
                         scope.snapDuration = snapDuration;
 
                         // TODO: perform initial snap without animation
-                        if (angular.isUndefined(scope.snapAnimation)) {
+                        if (isUndefined(scope.snapAnimation)) {
                             scope.snapAnimation = true;
                         }
 
-                        scope.preventSnappingAfterManualScroll = angular.isDefined(
+                        scope.preventSnappingAfterManualScroll = isDefined(
                             attributes.preventSnappingAfterManualScroll
                         );
 

--- a/src/directives/snapscroll.js
+++ b/src/directives/snapscroll.js
@@ -79,9 +79,6 @@
                             for (var j = innerSnapIndex; j >= 0; j--) {
                                 innerScrollTop -= snapHeight;
                             }
-                            if (innerScrollTop < 0) {
-                                innerScrollTop = 0;
-                            }
                         } else {
                             innerScrollTop = 0;
                             for (var i = 0; i < innerSnapIndex; i++) {
@@ -143,6 +140,9 @@
                                 scrollTop
                             ];
                         } else if (angular.isUndefined(scope.snapEasing)) {
+                            // TODO: add tests for this. Will require refactoring
+                            // the default values into an object, which is a good
+                            // change anyway
                             args = [
                                 element,
                                 scrollTop,
@@ -285,9 +285,6 @@
                     }
 
                     function isInnerSnapIndexValid(innerSnapIndex) {
-                        if (angular.isUndefined(innerSnapIndex)) {
-                            innerSnapIndex = scope.innerSnapIndex;
-                        }
                         if (innerSnapIndex < 0) {
                             return isSnapIndexValid(scope.snapIndex - 1);
                         }
@@ -299,17 +296,6 @@
 
                     function innerSnapIndexChanged(current, previous) {
                         if (angular.isUndefined(current)) {
-                            return;
-                        }
-                        if (scope.ignoreInnerSnapIndexChange === true) {
-                            scope.ignoreInnerSnapIndexChange = undefined;
-                            return;
-                        }
-                        if (!isInnerSnapIndexValid(current)) {
-                            if (isNumber(previous)) {
-                                scope.ignoreInnerSnapIndexChange = true;
-                                scope.innerSnapIndex = previous;
-                            }
                             return;
                         }
                         var newInnerSnapIndex, newSnapIndex;
@@ -378,9 +364,6 @@
                     }
 
                     function bindWheel() {
-                        if (scope.wheelBound) {
-                            return;
-                        }
                         wheelie.bind(element, {
                             up: function (e) {
                                 e.preventDefault();
@@ -395,15 +378,10 @@
                                 }
                             }
                         });
-                        scope.wheelBound = true;
                     }
 
                     function unbindWheel() {
-                        if (!scope.wheelBound) {
-                            return;
-                        }
                         wheelie.unbind(element);
-                        scope.wheelBound = false;
                     }
 
                     function setHeight(angularElement, height) {
@@ -511,22 +489,16 @@
                         if (scope.preventSnappingAfterManualScroll) {
                             return;
                         }
-                        if (scope.scrollBound) {
-                            return;
-                        }
                         if (angular.isDefined(scope.snapDirection)) { // still snapping
+                            // TODO: add tests for this
                             bindScrollAfterDelay();
                             return;
                         }
                         element.on('scroll', onScroll);
-                        scope.scrollBound = true;
                     }
 
                     function unbindScroll() {
-                        if (scope.scrollBound) {
-                            element.off('scroll', onScroll);
-                            scope.scrollBound = false;
-                        }
+                        element.off('scroll', onScroll);
                     }
 
                     function bindScrollAfterDelay() {
@@ -614,8 +586,10 @@
                         });
 
                         scope.$on('$destroy', function () {
-                            unbindScroll();
-                            unbindWheel();
+                            if (scope.enabled !== false) {
+                                unbindScroll();
+                                unbindWheel();
+                            }
                         });
                     }
 

--- a/src/directives/snapscroll.js
+++ b/src/directives/snapscroll.js
@@ -329,7 +329,7 @@
                             return;
                         }
                         if (scope.snapDirection === direction) {
-                            return;
+                            return true;
                         }
                         var newInnerSnapIndex;
                         if (direction === 'up') {

--- a/src/directives/snapscroll.js
+++ b/src/directives/snapscroll.js
@@ -245,6 +245,9 @@
                             return;
                         }
                         if (!isSnapIndexValid(current)) {
+                            if (!isSnapIndexValid(previous)) {
+                                previous = 0;
+                            }
                             scope.ignoreSnapIndexChange = true;
                             scope.snapIndex = previous;
                             return;

--- a/src/directives/snapscroll.js
+++ b/src/directives/snapscroll.js
@@ -104,10 +104,10 @@
                                 return;
                             }
                         }
-                        return snapTo(
+                        return scrollTo(getScrollTop(
                             scope.innerSnapIndex,
                             scope.snapIndex
-                        ).then(function () {
+                        )).then(function () {
                             if (scope.snapIndexChanged) {
                                 scope.afterSnap({
                                     snapIndex: scope.snapIndex
@@ -123,8 +123,7 @@
                         return element[0].scrollTop;
                     }
 
-                    function snapTo(innerSnapIndex, snapIndex) {
-                        var scrollTop = getScrollTop(innerSnapIndex, snapIndex);
+                    function scrollTo(scrollTop) {
                         var args;
                         if (!scope.snapAnimation) {
                             args = [

--- a/src/directives/snapscroll.js
+++ b/src/directives/snapscroll.js
@@ -56,6 +56,18 @@
                         return getHeight(element[0]);
                     }
 
+                    function getScrollHeight() {
+                        return element[0].scrollHeight;
+                    }
+
+                    function rectifyScrollTop(scrollTop) {
+                        var maxScrollTop = getScrollHeight() - getSnapHeight();
+                        if (scrollTop > maxScrollTop) {
+                            return maxScrollTop;
+                        }
+                        return scrollTop;
+                    }
+
                     function getScrollTop(compositeIndex, previousCompositeIndex) {
                         var snapIndex = compositeIndex[0];
                         var innerSnapIndex = compositeIndex[1];
@@ -67,7 +79,7 @@
                         }
 
                         if (innerSnapIndex === 0) {
-                            return scrollTop;
+                            return rectifyScrollTop(scrollTop);
                         }
 
                         var snapHeight = getSnapHeight();
@@ -90,7 +102,7 @@
                             }
                         }
 
-                        return scrollTop + innerScrollTop;
+                        return rectifyScrollTop(scrollTop + innerScrollTop);
                     }
 
                     function snapTo(compositeIndex, previousCompositeIndex) {

--- a/src/directives/snapscroll.js
+++ b/src/directives/snapscroll.js
@@ -566,8 +566,7 @@
                                     indeces.snapIndex
                                 );
                             }
-                            var enabled = current !== false;
-                            if (enabled) {
+                            if (current !== false) {
                                 if (previous === false) {
                                     updateIndecesFromScrollTop();
                                 }

--- a/test/spec/directives/snapscroll.js
+++ b/test/spec/directives/snapscroll.js
@@ -261,9 +261,8 @@ describe('Directive: snapscroll', function () {
     }
 
     function testPreventsBubblingUpOfMousewheelEventsIfElementIsStillScrollable(html) {
-        var element,
-            stopPropagation = jasmine.createSpy('stopPropagation');
-        element = compileElement(html, true);
+        var stopPropagation = jasmine.createSpy('stopPropagation');
+        var element = compileElement(html, true);
         element.triggerHandler({
             type: 'wheel',
             wheelDelta: 120,
@@ -578,6 +577,7 @@ describe('Directive: snapscroll', function () {
                         if (angular.isFunction(success)) {
                             success();
                         }
+                        return this;
                     }
                 };
             });

--- a/test/spec/directives/snapscroll.js
+++ b/test/spec/directives/snapscroll.js
@@ -333,6 +333,36 @@ describe('Directive: snapscroll', function () {
         expect(element[0].scrollTop).toBe(150);
     }
 
+    function testSnapsUpOnMousewheelUp(html) {
+        var element;
+        $scope.index = 3;
+        element = compileElement(html, true);
+        element.triggerHandler({
+            type: 'wheel',
+            wheelDelta: 120,
+            detail: -120,
+            deltaY: -120
+        });
+        expect($scope.index).toBe(2);
+        expect(element[0].scrollTop).toBe(100);
+        element.triggerHandler({
+            type: 'mousewheel',
+            wheelDelta: 120,
+            detail: -120,
+            deltaY: -120
+        });
+        expect($scope.index).toBe(1);
+        expect(element[0].scrollTop).toBe(50);
+        element.triggerHandler({
+            type: 'onmousewheel',
+            wheelDelta: 120,
+            detail: -120,
+            deltaY: -120
+        });
+        expect($scope.index).toBe(0);
+        expect(element[0].scrollTop).toBe(0);
+    }
+
     function testShowsRestOfBigSnapOnMousewheelDown(html) {
         var element;
         element = compileElement(html, true);
@@ -378,36 +408,6 @@ describe('Directive: snapscroll', function () {
         });
         expect($scope.index).toBe(3);
         expect(element[0].scrollTop).toBe(225);
-    }
-
-    function testSnapsUpOnMousewheelUp(html) {
-        var element;
-        $scope.index = 3;
-        element = compileElement(html, true);
-        element.triggerHandler({
-            type: 'wheel',
-            wheelDelta: 120,
-            detail: -120,
-            deltaY: -120
-        });
-        expect($scope.index).toBe(2);
-        expect(element[0].scrollTop).toBe(100);
-        element.triggerHandler({
-            type: 'mousewheel',
-            wheelDelta: 120,
-            detail: -120,
-            deltaY: -120
-        });
-        expect($scope.index).toBe(1);
-        expect(element[0].scrollTop).toBe(50);
-        element.triggerHandler({
-            type: 'onmousewheel',
-            wheelDelta: 120,
-            detail: -120,
-            deltaY: -120
-        });
-        expect($scope.index).toBe(0);
-        expect(element[0].scrollTop).toBe(0);
     }
 
     function testShowsRestOfBigSnapOnMousewheelUp(html) {

--- a/test/spec/directives/snapscroll.js
+++ b/test/spec/directives/snapscroll.js
@@ -333,6 +333,51 @@ describe('Directive: snapscroll', function () {
         expect(element[0].scrollTop).toBe(150);
     }
 
+    function testShowsRestOfBigSnapOnMousewheelDown(html) {
+        var element;
+        element = compileElement(html, true);
+        element.triggerHandler({
+            type: 'wheel',
+            wheelDelta: -120,
+            detail: 120,
+            deltaY: 120
+        });
+        expect($scope.index).toBe(1);
+        expect(element[0].scrollTop).toBe(50);
+        element.triggerHandler({
+            type: 'mousewheel',
+            wheelDelta: -120,
+            detail: 120,
+            deltaY: 120
+        });
+        expect($scope.index).toBe(1);
+        expect(element[0].scrollTop).toBe(100);
+        element.triggerHandler({
+            type: 'onmousewheel',
+            wheelDelta: -120,
+            detail: 120,
+            deltaY: 120
+        });
+        expect($scope.index).toBe(1);
+        expect(element[0].scrollTop).toBe(125);
+        element.triggerHandler({
+            type: 'onmousewheel',
+            wheelDelta: -120,
+            detail: 120,
+            deltaY: 120
+        });
+        expect($scope.index).toBe(2);
+        expect(element[0].scrollTop).toBe(175);
+        element.triggerHandler({
+            type: 'onmousewheel',
+            wheelDelta: -120,
+            detail: 120,
+            deltaY: 120
+        });
+        expect($scope.index).toBe(3);
+        expect(element[0].scrollTop).toBe(225);
+    }
+
     function testSnapsUpOnMousewheelUp(html) {
         var element;
         $scope.index = 3;
@@ -347,6 +392,52 @@ describe('Directive: snapscroll', function () {
         expect(element[0].scrollTop).toBe(100);
         element.triggerHandler({
             type: 'mousewheel',
+            wheelDelta: 120,
+            detail: -120,
+            deltaY: -120
+        });
+        expect($scope.index).toBe(1);
+        expect(element[0].scrollTop).toBe(50);
+        element.triggerHandler({
+            type: 'onmousewheel',
+            wheelDelta: 120,
+            detail: -120,
+            deltaY: -120
+        });
+        expect($scope.index).toBe(0);
+        expect(element[0].scrollTop).toBe(0);
+    }
+
+    function testShowsRestOfBigSnapOnMousewheelUp(html) {
+        var element;
+        $scope.index = 3;
+        element = compileElement(html, true);
+        element.triggerHandler({
+            type: 'wheel',
+            wheelDelta: 120,
+            detail: -120,
+            deltaY: -120
+        });
+        expect($scope.index).toBe(2);
+        expect(element[0].scrollTop).toBe(175);
+        element.triggerHandler({
+            type: 'mousewheel',
+            wheelDelta: 120,
+            detail: -120,
+            deltaY: -120
+        });
+        expect($scope.index).toBe(1);
+        expect(element[0].scrollTop).toBe(125);
+        element.triggerHandler({
+            type: 'onmousewheel',
+            wheelDelta: 120,
+            detail: -120,
+            deltaY: -120
+        });
+        expect($scope.index).toBe(1);
+        expect(element[0].scrollTop).toBe(75);
+        element.triggerHandler({
+            type: 'onmousewheel',
             wheelDelta: 120,
             detail: -120,
             deltaY: -120
@@ -1306,6 +1397,30 @@ describe('Directive: snapscroll', function () {
                 '</div>'
             ].join('');
             testSnapsUpOnMousewheelUp(html);
+        });
+
+        it('shows the rest of a snap instead of snapping down if it\'s greater than the snapHeight on mouseheel down', function () {
+            var html = [
+                '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
+                '<div style="height: 50px"></div>',
+                '<div style="height: 125px"></div>',
+                '<div style="height: 50px"></div>',
+                '<div style="height: 50px"></div>',
+                '</div>'
+            ].join('');
+            testShowsRestOfBigSnapOnMousewheelDown(html);
+        });
+
+        it('shows the rest of a snap instead of snapping up if it\'s greater than the snapHeight on mouseheel up', function () {
+            var html = [
+                '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
+                '<div style="height: 50px"></div>',
+                '<div style="height: 125px"></div>',
+                '<div style="height: 50px"></div>',
+                '<div style="height: 50px"></div>',
+                '</div>'
+            ].join('');
+            testShowsRestOfBigSnapOnMousewheelUp(html);
         });
 
         it('doens\'t snap down on a new down-mousewheel event if the element is already scrolled to the end', function () {

--- a/test/spec/directives/snapscroll.js
+++ b/test/spec/directives/snapscroll.js
@@ -1203,7 +1203,7 @@ describe('Directive: snapscroll', function () {
             expect(element[0].scrollTop).toBe(0);
         });
 
-        it('allows disabling snapscroll by passing false as the snapscroll attribute value', function () {
+        it('allows disabling snapscroll by passing \'false\' as the snapscroll attribute value', function () {
             var element,
                 html = [
                     '<div snapscroll="false" snap-index="index" style="height: 50px; overflow: auto">',

--- a/test/spec/directives/snapscroll.js
+++ b/test/spec/directives/snapscroll.js
@@ -2717,6 +2717,27 @@ describe('Directive: snapscroll', function () {
             expect(scrollMock.to.calls.count()).toEqual(2); // not called again
         }
 
+        function testStopsPropagationIfCurrentlySnappingInTheDirectionOfANewMousewheel(html) {
+            var element = compileElement(html, true);
+            var stopPropagation = jasmine.createSpy('stopPropagation');
+            element.triggerHandler({
+                type: 'wheel',
+                wheelDelta: -120,
+                detail: 120,
+                deltaY: 120,
+                stopPropagation: stopPropagation
+            }); // snap down to 50
+            expect(stopPropagation.calls.count()).toBe(1);
+            element.triggerHandler({
+                type: 'wheel',
+                wheelDelta: -120,
+                detail: 120,
+                deltaY: 120,
+                stopPropagation: stopPropagation
+            }); // while snapping, snap down to 100
+            expect(stopPropagation.calls.count()).toBe(2);
+        }
+
         function testAllowsSnapingInTheOppositeDirectionOnNewMousewheelIfCurrentlySnapping(html) {
             var element;
             element = compileElement(html, true);
@@ -2760,7 +2781,7 @@ describe('Directive: snapscroll', function () {
             });
         });
 
-        it('doesn\'t snap in the same direction as a new mousewheel event if currently snapping', function () {
+        it('doesn\'t snap in the same direction on a new mousewheel event if currently snapping', function () {
             var html = [
                 '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
                 '<div style="height: 50px"></div>',
@@ -2770,6 +2791,18 @@ describe('Directive: snapscroll', function () {
                 '</div>'
             ].join('');
             testDoesntSnapInTheSameDirectionOnNewMousewheelIfCurrentlySnapping(html);
+        });
+
+        it('doesn\'t bubble up the mousewheel event if currently snapping in the direction of a new mousewheel event', function () {
+            var html = [
+                '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
+                '<div style="height: 50px"></div>',
+                '<div style="height: 50px"></div>',
+                '<div style="height: 50px"></div>',
+                '<div style="height: 50px"></div>',
+                '</div>'
+            ].join('');
+            testStopsPropagationIfCurrentlySnappingInTheDirectionOfANewMousewheel(html);
         });
 
         it('allows snapping in the opposite direction as a new mousewheel event if currently snapping', function () {

--- a/test/spec/directives/snapscroll.js
+++ b/test/spec/directives/snapscroll.js
@@ -1127,6 +1127,36 @@ describe('Directive: snapscroll', function () {
             expect(element[0].scrollTop).toBe(0);
         });
 
+        it('defaults snapIndex to zero if the provided snapIndex is less than zero', function () {
+            var element,
+                html = [
+                    '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '</div>'
+                ].join('');
+            $scope.index = -1;
+            element = compileElement(html, true);
+            expect($scope.index).toBe(0);
+            expect(element[0].scrollTop).toBe(0);
+        });
+
+        it('defaults snapIndex to zero if the provided snapIndex is greater than upper snapIndex limit', function () {
+            var element,
+                html = [
+                    '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '</div>'
+                ].join('');
+            $scope.index = 3;
+            element = compileElement(html, true);
+            expect($scope.index).toBe(0);
+            expect(element[0].scrollTop).toBe(0);
+        });
+
         it('ignores changes to snapIndex if a non-number value is provided', function () {
             var html = [
                 '<div snapscroll="" snap-index="snapIndex" style="height: 50px; overflow: auto">',

--- a/test/spec/directives/snapscroll.js
+++ b/test/spec/directives/snapscroll.js
@@ -362,6 +362,177 @@ describe('Directive: snapscroll', function () {
         expect(element[0].scrollTop).toBe(0);
     }
 
+    function testExecutesBeforeSnapOnMousewheelDown(html) {
+        var spy = jasmine.createSpy('beforeSnap');
+        $scope.beforeSnap = spy;
+        var element = compileElement(html, true);
+        expect(spy).toHaveBeenCalledWith(0); // initial snap
+        spy.reset();
+        element.triggerHandler({
+            type: 'wheel',
+            wheelDelta: -120,
+            detail: 120,
+            deltaY: 120
+        });
+        expect(spy).toHaveBeenCalledWith(1);
+        spy.reset();
+        element.triggerHandler({
+            type: 'mousewheel',
+            wheelDelta: -120,
+            detail: 120,
+            deltaY: 120
+        });
+        expect(spy).toHaveBeenCalledWith(1); // index still 1
+        spy.reset();
+        element.triggerHandler({
+            type: 'onmousewheel',
+            wheelDelta: -120,
+            detail: 120,
+            deltaY: 120
+        });
+        expect(spy).toHaveBeenCalledWith(1); // index still 1
+        spy.reset();
+        element.triggerHandler({
+            type: 'onmousewheel',
+            wheelDelta: -120,
+            detail: 120,
+            deltaY: 120
+        });
+        expect(spy).toHaveBeenCalledWith(2);
+        spy.reset();
+        element.triggerHandler({
+            type: 'onmousewheel',
+            wheelDelta: -120,
+            detail: 120,
+            deltaY: 120
+        });
+        expect(spy).toHaveBeenCalledWith(3);
+        spy.reset();
+    }
+
+    function testExecutesBeforeSnapOnMousewheelUp(html) {
+        var spy = jasmine.createSpy('beforeSnap');
+        $scope.beforeSnap = spy;
+        $scope.index = 3;
+        var element = compileElement(html, true);
+        expect(spy).toHaveBeenCalledWith(3); // initial snap
+        spy.reset();
+        element.triggerHandler({
+            type: 'wheel',
+            wheelDelta: 120,
+            detail: -120,
+            deltaY: -120
+        });
+        expect(spy).toHaveBeenCalledWith(2);
+        spy.reset();
+        element.triggerHandler({
+            type: 'mousewheel',
+            wheelDelta: 120,
+            detail: -120,
+            deltaY: -120
+        });
+        expect(spy).toHaveBeenCalledWith(1);
+        spy.reset();
+        element.triggerHandler({
+            type: 'onmousewheel',
+            wheelDelta: 120,
+            detail: -120,
+            deltaY: -120
+        });
+        expect(spy).toHaveBeenCalledWith(1); // index still 1
+        spy.reset();
+        element.triggerHandler({
+            type: 'onmousewheel',
+            wheelDelta: 120,
+            detail: -120,
+            deltaY: -120
+        });
+        expect(spy).toHaveBeenCalledWith(1); // index still 1
+        spy.reset();
+        element.triggerHandler({
+            type: 'onmousewheel',
+            wheelDelta: 120,
+            detail: -120,
+            deltaY: -120
+        });
+        expect(spy).toHaveBeenCalledWith(0);
+        spy.reset();
+    }
+
+    function testDoesNotSnapDownIfBeforeSnapReturnsFalseOnMousewheelDown(html) {
+        var spy = jasmine.createSpy('beforeSnap').and.callFake(function (snapIndex) {
+            if (snapIndex === 1) {
+                return false;
+            }
+        });
+        $scope.beforeSnap = spy;
+        var element = compileElement(html, true);
+        element.triggerHandler({
+            type: 'wheel',
+            wheelDelta: -120,
+            detail: 120,
+            deltaY: 120
+        });
+        expect(spy).toHaveBeenCalledWith(1);
+        expect($scope.index).toBe(0);
+    }
+
+    function testDoesNotSnapUpIfBeforeSnapReturnsFalseOnMousewheelUp(html) {
+        var spy = jasmine.createSpy('beforeSnap').and.callFake(function (snapIndex) {
+            if (snapIndex === 2) {
+                return false;
+            }
+        });
+        $scope.beforeSnap = spy;
+        $scope.index = 3;
+        var element = compileElement(html, true);
+        element.triggerHandler({
+            type: 'wheel',
+            wheelDelta: 120,
+            detail: -120,
+            deltaY: -120
+        });
+        expect(spy).toHaveBeenCalledWith(2);
+        expect($scope.index).toBe(3);
+    }
+
+    function testSnapsToADifferentSnapIndexIfBeforeSnapReturnsNumberOnMousewheelDown(html) {
+        var spy = jasmine.createSpy('beforeSnap').and.callFake(function (snapIndex) {
+            if (snapIndex === 1) {
+                return 2;
+            }
+        });
+        $scope.beforeSnap = spy;
+        var element = compileElement(html, true);
+        element.triggerHandler({
+            type: 'wheel',
+            wheelDelta: -120,
+            detail: 120,
+            deltaY: 120
+        });
+        expect(spy).toHaveBeenCalledWith(1);
+        expect($scope.index).toBe(2);
+    }
+
+    function testSnapsToADifferentSnapIndexIfBeforeSnapReturnsNumberOnMousewheelUp(html) {
+        var spy = jasmine.createSpy('beforeSnap').and.callFake(function (snapIndex) {
+            if (snapIndex === 2) {
+                return 1;
+            }
+        });
+        $scope.beforeSnap = spy;
+        $scope.index = 3;
+        var element = compileElement(html, true);
+        element.triggerHandler({
+            type: 'wheel',
+            wheelDelta: 120,
+            detail: -120,
+            deltaY: -120
+        });
+        expect(spy).toHaveBeenCalledWith(2);
+        expect($scope.index).toBe(1);
+    }
+
     function testShowsRestOfBigSnapOnMousewheelDown(html) {
         var element;
         element = compileElement(html, true);
@@ -1401,6 +1572,78 @@ describe('Directive: snapscroll', function () {
                 '</div>'
             ].join('');
             testSnapsUpOnMousewheelUp(html);
+        });
+
+        it('executes beforeSnap on mouseheel down', function () {
+            var html = [
+                '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
+                '<div style="height: 50px"></div>',
+                '<div style="height: 50px"></div>',
+                '<div style="height: 50px"></div>',
+                '<div style="height: 50px"></div>',
+                '</div>'
+            ].join('');
+            testExecutesBeforeSnapOnMousewheelDown(html);
+        });
+
+        it('executes beforeSnap on mouseheel up', function () {
+            var html = [
+                '<div snapscroll="" snap-index="index" before-snap="beforeSnap()" style="height: 50px; overflow: auto">',
+                '<div style="height: 50px"></div>',
+                '<div style="height: 50px"></div>',
+                '<div style="height: 50px"></div>',
+                '<div style="height: 50px"></div>',
+                '</div>'
+            ].join('');
+            testExecutesBeforeSnapOnMousewheelUp(html);
+        });
+
+        it('does not snap down if beforeSnap returns false on mouseheel down', function () {
+            var html = [
+                '<div snapscroll="" snap-index="index" before-snap="beforeSnap()" style="height: 50px; overflow: auto">',
+                '<div style="height: 50px"></div>',
+                '<div style="height: 50px"></div>',
+                '<div style="height: 50px"></div>',
+                '<div style="height: 50px"></div>',
+                '</div>'
+            ].join('');
+            testDoesNotSnapDownIfBeforeSnapReturnsFalseOnMousewheelDown(html);
+        });
+
+        it('does not snap up if beforeSnap returns false on mouseheel up', function () {
+            var html = [
+                '<div snapscroll="" snap-index="index" before-snap="beforeSnap()" style="height: 50px; overflow: auto">',
+                '<div style="height: 50px"></div>',
+                '<div style="height: 50px"></div>',
+                '<div style="height: 50px"></div>',
+                '<div style="height: 50px"></div>',
+                '</div>'
+            ].join('');
+            testDoesNotSnapUpIfBeforeSnapReturnsFalseOnMousewheelUp(html);
+        });
+
+        it('snaps to a different snapIndex if beforeSnap returns a number on mouseheel down', function () {
+            var html = [
+                '<div snapscroll="" snap-index="index" before-snap="beforeSnap()" style="height: 50px; overflow: auto">',
+                '<div style="height: 50px"></div>',
+                '<div style="height: 50px"></div>',
+                '<div style="height: 50px"></div>',
+                '<div style="height: 50px"></div>',
+                '</div>'
+            ].join('');
+            testSnapsToADifferentSnapIndexIfBeforeSnapReturnsNumberOnMousewheelDown(html);
+        });
+
+        it('snaps to a different snapIndex if beforeSnap returns a number on mouseheel up', function () {
+            var html = [
+                '<div snapscroll="" snap-index="index" before-snap="beforeSnap()" style="height: 50px; overflow: auto">',
+                '<div style="height: 50px"></div>',
+                '<div style="height: 50px"></div>',
+                '<div style="height: 50px"></div>',
+                '<div style="height: 50px"></div>',
+                '</div>'
+            ].join('');
+            testSnapsToADifferentSnapIndexIfBeforeSnapReturnsNumberOnMousewheelUp(html);
         });
 
         it('shows the rest of a snap instead of snapping down if it\'s greater than the snapHeight on mouseheel down', function () {

--- a/test/spec/directives/snapscroll.js
+++ b/test/spec/directives/snapscroll.js
@@ -336,6 +336,8 @@ describe('Directive: snapscroll', function () {
     function testShowsRestOfBigSnapOnMousewheelDown(html) {
         var element;
         element = compileElement(html, true);
+        expect($scope.index).toBe(0);
+        expect(element[0].scrollTop).toBe(0);
         element.triggerHandler({
             type: 'wheel',
             wheelDelta: -120,
@@ -412,6 +414,8 @@ describe('Directive: snapscroll', function () {
         var element;
         $scope.index = 3;
         element = compileElement(html, true);
+        expect($scope.index).toBe(3);
+        expect(element[0].scrollTop).toBe(225);
         element.triggerHandler({
             type: 'wheel',
             wheelDelta: 120,

--- a/test/spec/directives/snapscroll.js
+++ b/test/spec/directives/snapscroll.js
@@ -1828,7 +1828,7 @@ describe('Directive: snapscroll', function () {
             testPreventsBubblingUpOfMousewheelEventsIfElementIsStillScrollable(html);
         });
 
-        describe('on mouseheel down', function () {
+        describe('on mousewheel down', function () {
             it('snaps down', function () {
                 var html = [
                     '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
@@ -1851,7 +1851,7 @@ describe('Directive: snapscroll', function () {
 
             it('executes beforeSnap', function () {
                 var html = [
-                    '<div snapscroll="" snap-index="index" before-snap="beforeSnap(index)" style="height: 50px; overflow: auto">',
+                    '<div snapscroll="" snap-index="index" before-snap="beforeSnap(snapIndex)" style="height: 50px; overflow: auto">',
                     '<div style="height: 50px"></div>',
                     '<div style="height: 125px"></div>',
                     '<div style="height: 50px"></div>',
@@ -1863,7 +1863,7 @@ describe('Directive: snapscroll', function () {
 
             it('does not snap down if beforeSnap returns false', function () {
                 var html = [
-                    '<div snapscroll="" snap-index="index" before-snap="beforeSnap(index)" style="height: 50px; overflow: auto">',
+                    '<div snapscroll="" snap-index="index" before-snap="beforeSnap(snapIndex)" style="height: 50px; overflow: auto">',
                     '<div style="height: 50px"></div>',
                     '<div style="height: 50px"></div>',
                     '<div style="height: 50px"></div>',
@@ -1875,7 +1875,7 @@ describe('Directive: snapscroll', function () {
 
             it('snaps to a different snapIndex if beforeSnap returns a number', function () {
                 var html = [
-                    '<div snapscroll="" snap-index="index" before-snap="beforeSnap(index)" style="height: 50px; overflow: auto">',
+                    '<div snapscroll="" snap-index="index" before-snap="beforeSnap(snapIndex)" style="height: 50px; overflow: auto">',
                     '<div style="height: 50px"></div>',
                     '<div style="height: 50px"></div>',
                     '<div style="height: 50px"></div>',
@@ -1920,7 +1920,7 @@ describe('Directive: snapscroll', function () {
             });
         });
 
-        describe('on mouseheel down', function () {
+        describe('on mousewheel up', function () {
             it('snaps up', function () {
                 var html = [
                     '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
@@ -1943,7 +1943,7 @@ describe('Directive: snapscroll', function () {
 
             it('executes beforeSnap', function () {
                 var html = [
-                    '<div snapscroll="" snap-index="index" before-snap="beforeSnap(index)" style="height: 50px; overflow: auto">',
+                    '<div snapscroll="" snap-index="index" before-snap="beforeSnap(snapIndex)" style="height: 50px; overflow: auto">',
                     '<div style="height: 50px"></div>',
                     '<div style="height: 125px"></div>',
                     '<div style="height: 50px"></div>',
@@ -1955,7 +1955,7 @@ describe('Directive: snapscroll', function () {
 
             it('does not snap up if beforeSnap returns false', function () {
                 var html = [
-                    '<div snapscroll="" snap-index="index" before-snap="beforeSnap(index)" style="height: 50px; overflow: auto">',
+                    '<div snapscroll="" snap-index="index" before-snap="beforeSnap(snapIndex)" style="height: 50px; overflow: auto">',
                     '<div style="height: 50px"></div>',
                     '<div style="height: 50px"></div>',
                     '<div style="height: 50px"></div>',
@@ -1967,7 +1967,7 @@ describe('Directive: snapscroll', function () {
 
             it('snaps to a different snapIndex if beforeSnap returns a number', function () {
                 var html = [
-                    '<div snapscroll="" snap-index="index" before-snap="beforeSnap(index)" style="height: 50px; overflow: auto">',
+                    '<div snapscroll="" snap-index="index" before-snap="beforeSnap(snapIndex)" style="height: 50px; overflow: auto">',
                     '<div style="height: 50px"></div>',
                     '<div style="height: 50px"></div>',
                     '<div style="height: 50px"></div>',

--- a/test/spec/directives/snapscroll.js
+++ b/test/spec/directives/snapscroll.js
@@ -360,7 +360,7 @@ describe('Directive: snapscroll', function () {
         $scope.beforeSnap = spy;
         var element = compileElement(html, true);
         expect(spy).toHaveBeenCalledWith(0); // initial snap
-        spy.reset();
+        spy.calls.reset();
         element.triggerHandler({
             type: 'wheel',
             wheelDelta: -120,
@@ -368,23 +368,23 @@ describe('Directive: snapscroll', function () {
             deltaY: 120
         });
         expect(spy).toHaveBeenCalledWith(1);
-        spy.reset();
+        spy.calls.reset();
         element.triggerHandler({
             type: 'mousewheel',
             wheelDelta: -120,
             detail: 120,
             deltaY: 120
         });
-        expect(spy).toHaveBeenCalledWith(1); // index still 1
-        spy.reset();
+        expect(spy).not.toHaveBeenCalled(); // index still 1
+        spy.calls.reset();
         element.triggerHandler({
             type: 'onmousewheel',
             wheelDelta: -120,
             detail: 120,
             deltaY: 120
         });
-        expect(spy).toHaveBeenCalledWith(1); // index still 1
-        spy.reset();
+        expect(spy).not.toHaveBeenCalled(); // index still 1
+        spy.calls.reset();
         element.triggerHandler({
             type: 'onmousewheel',
             wheelDelta: -120,
@@ -392,7 +392,7 @@ describe('Directive: snapscroll', function () {
             deltaY: 120
         });
         expect(spy).toHaveBeenCalledWith(2);
-        spy.reset();
+        spy.calls.reset();
         element.triggerHandler({
             type: 'onmousewheel',
             wheelDelta: -120,
@@ -400,7 +400,7 @@ describe('Directive: snapscroll', function () {
             deltaY: 120
         });
         expect(spy).toHaveBeenCalledWith(3);
-        spy.reset();
+        spy.calls.reset();
     }
 
     function testExecutesBeforeSnapOnMousewheelUp(html) {
@@ -409,7 +409,7 @@ describe('Directive: snapscroll', function () {
         $scope.index = 3;
         var element = compileElement(html, true);
         expect(spy).toHaveBeenCalledWith(3); // initial snap
-        spy.reset();
+        spy.calls.reset();
         element.triggerHandler({
             type: 'wheel',
             wheelDelta: 120,
@@ -417,7 +417,7 @@ describe('Directive: snapscroll', function () {
             deltaY: -120
         });
         expect(spy).toHaveBeenCalledWith(2);
-        spy.reset();
+        spy.calls.reset();
         element.triggerHandler({
             type: 'mousewheel',
             wheelDelta: 120,
@@ -425,23 +425,23 @@ describe('Directive: snapscroll', function () {
             deltaY: -120
         });
         expect(spy).toHaveBeenCalledWith(1);
-        spy.reset();
+        spy.calls.reset();
         element.triggerHandler({
             type: 'onmousewheel',
             wheelDelta: 120,
             detail: -120,
             deltaY: -120
         });
-        expect(spy).toHaveBeenCalledWith(1); // index still 1
-        spy.reset();
+        expect(spy).not.toHaveBeenCalled(); // index still 1
+        spy.calls.reset();
         element.triggerHandler({
             type: 'onmousewheel',
             wheelDelta: 120,
             detail: -120,
             deltaY: -120
         });
-        expect(spy).toHaveBeenCalledWith(1); // index still 1
-        spy.reset();
+        expect(spy).not.toHaveBeenCalled(); // index still 1
+        spy.calls.reset();
         element.triggerHandler({
             type: 'onmousewheel',
             wheelDelta: 120,
@@ -449,7 +449,7 @@ describe('Directive: snapscroll', function () {
             deltaY: -120
         });
         expect(spy).toHaveBeenCalledWith(0);
-        spy.reset();
+        spy.calls.reset();
     }
 
     function testDoesNotSnapDownIfBeforeSnapReturnsFalseOnMousewheelDown(html) {
@@ -1708,9 +1708,9 @@ describe('Directive: snapscroll', function () {
 
         it('executes beforeSnap on mouseheel down', function () {
             var html = [
-                '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
+                '<div snapscroll="" snap-index="index" before-snap="beforeSnap(index)" style="height: 50px; overflow: auto">',
                 '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
+                '<div style="height: 125px"></div>',
                 '<div style="height: 50px"></div>',
                 '<div style="height: 50px"></div>',
                 '</div>'
@@ -1720,9 +1720,9 @@ describe('Directive: snapscroll', function () {
 
         it('executes beforeSnap on mouseheel up', function () {
             var html = [
-                '<div snapscroll="" snap-index="index" before-snap="beforeSnap()" style="height: 50px; overflow: auto">',
+                '<div snapscroll="" snap-index="index" before-snap="beforeSnap(index)" style="height: 50px; overflow: auto">',
                 '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
+                '<div style="height: 125px"></div>',
                 '<div style="height: 50px"></div>',
                 '<div style="height: 50px"></div>',
                 '</div>'
@@ -1732,7 +1732,7 @@ describe('Directive: snapscroll', function () {
 
         it('does not snap down if beforeSnap returns false on mouseheel down', function () {
             var html = [
-                '<div snapscroll="" snap-index="index" before-snap="beforeSnap()" style="height: 50px; overflow: auto">',
+                '<div snapscroll="" snap-index="index" before-snap="beforeSnap(index)" style="height: 50px; overflow: auto">',
                 '<div style="height: 50px"></div>',
                 '<div style="height: 50px"></div>',
                 '<div style="height: 50px"></div>',
@@ -1744,7 +1744,7 @@ describe('Directive: snapscroll', function () {
 
         it('does not snap up if beforeSnap returns false on mouseheel up', function () {
             var html = [
-                '<div snapscroll="" snap-index="index" before-snap="beforeSnap()" style="height: 50px; overflow: auto">',
+                '<div snapscroll="" snap-index="index" before-snap="beforeSnap(index)" style="height: 50px; overflow: auto">',
                 '<div style="height: 50px"></div>',
                 '<div style="height: 50px"></div>',
                 '<div style="height: 50px"></div>',
@@ -1756,7 +1756,7 @@ describe('Directive: snapscroll', function () {
 
         it('snaps to a different snapIndex if beforeSnap returns a number on mouseheel down', function () {
             var html = [
-                '<div snapscroll="" snap-index="index" before-snap="beforeSnap()" style="height: 50px; overflow: auto">',
+                '<div snapscroll="" snap-index="index" before-snap="beforeSnap(index)" style="height: 50px; overflow: auto">',
                 '<div style="height: 50px"></div>',
                 '<div style="height: 50px"></div>',
                 '<div style="height: 50px"></div>',
@@ -1768,7 +1768,7 @@ describe('Directive: snapscroll', function () {
 
         it('snaps to a different snapIndex if beforeSnap returns a number on mouseheel up', function () {
             var html = [
-                '<div snapscroll="" snap-index="index" before-snap="beforeSnap()" style="height: 50px; overflow: auto">',
+                '<div snapscroll="" snap-index="index" before-snap="beforeSnap(index)" style="height: 50px; overflow: auto">',
                 '<div style="height: 50px"></div>',
                 '<div style="height: 50px"></div>',
                 '<div style="height: 50px"></div>',

--- a/test/spec/directives/snapscroll.js
+++ b/test/spec/directives/snapscroll.js
@@ -325,6 +325,21 @@ describe('Directive: snapscroll', function () {
         expect(element[0].scrollTop).toBe(150);
     }
 
+    function testDoesntSnapDownIfElementIsNotScrollable(html) {
+        var element;
+        element = compileElement(html, true);
+        expect($scope.index).toBeUndefined();
+        expect(element[0].scrollTop).toBe(0);
+        element.triggerHandler({
+            type: 'wheel',
+            wheelDelta: -120,
+            detail: 120,
+            deltaY: 120
+        });
+        expect($scope.index).toBeUndefined();
+        expect(element[0].scrollTop).toBe(0);
+    }
+
     function testSnapsUpOnMousewheelUp(html) {
         var element;
         $scope.index = 3;
@@ -352,6 +367,21 @@ describe('Directive: snapscroll', function () {
             deltaY: -120
         });
         expect($scope.index).toBe(0);
+        expect(element[0].scrollTop).toBe(0);
+    }
+
+    function testDoesntSnapUpIfElementIsNotScrollable(html) {
+        var element;
+        element = compileElement(html, true);
+        expect($scope.index).toBeUndefined();
+        expect(element[0].scrollTop).toBe(0);
+        element.triggerHandler({
+            type: 'wheel',
+            wheelDelta: 120,
+            detail: -120,
+            deltaY: -120
+        });
+        expect($scope.index).toBeUndefined();
         expect(element[0].scrollTop).toBe(0);
     }
 
@@ -664,6 +694,85 @@ describe('Directive: snapscroll', function () {
         });
         expect($scope.index).toBe(1);
         expect(element[0].scrollTop).toBe(50);
+    }
+
+    function testDoesntSnapDownIfBiggerHeightChildIsScrolledToTheEnd(html) {
+        var element;
+        element = compileElement(html, true);
+        expect($scope.index).toBe(0);
+        expect(element[0].scrollTop).toBe(0);
+        element.triggerHandler({
+            type: 'wheel',
+            wheelDelta: -120,
+            detail: 120,
+            deltaY: 120
+        });
+        expect($scope.index).toBe(1);
+        expect(element[0].scrollTop).toBe(50);
+        element.triggerHandler({
+            type: 'mousewheel',
+            wheelDelta: -120,
+            detail: 120,
+            deltaY: 120
+        });
+        expect($scope.index).toBe(1);
+        expect(element[0].scrollTop).toBe(100);
+        element.triggerHandler({
+            type: 'onmousewheel',
+            wheelDelta: -120,
+            detail: 120,
+            deltaY: 120
+        });
+        expect($scope.index).toBe(1);
+        expect(element[0].scrollTop).toBe(125);
+        element.triggerHandler({
+            type: 'onmousewheel',
+            wheelDelta: -120,
+            detail: 120,
+            deltaY: 120
+        });
+        expect($scope.index).toBe(1);
+        expect(element[0].scrollTop).toBe(125);
+    }
+
+    function testDoesntSnapDownIfBiggerHeightChildIsScrolledToTheBeginning(html) {
+        var element;
+        $scope.index = 1;
+        element = compileElement(html, true);
+        expect($scope.index).toBe(1);
+        expect(element[0].scrollTop).toBe(125);
+        element.triggerHandler({
+            type: 'wheel',
+            wheelDelta: 120,
+            detail: -120,
+            deltaY: -120
+        });
+        expect($scope.index).toBe(0);
+        expect(element[0].scrollTop).toBe(75);
+        element.triggerHandler({
+            type: 'mousewheel',
+            wheelDelta: 120,
+            detail: -120,
+            deltaY: -120
+        });
+        expect($scope.index).toBe(0);
+        expect(element[0].scrollTop).toBe(25);
+        element.triggerHandler({
+            type: 'onmousewheel',
+            wheelDelta: 120,
+            detail: -120,
+            deltaY: -120
+        });
+        expect($scope.index).toBe(0);
+        expect(element[0].scrollTop).toBe(0);
+        element.triggerHandler({
+            type: 'onmousewheel',
+            wheelDelta: 120,
+            detail: -120,
+            deltaY: -120
+        });
+        expect($scope.index).toBe(0);
+        expect(element[0].scrollTop).toBe(0);
     }
 
     function testStopsListeningToMousewheelWhenScopeIsDestroyed(html) {
@@ -1105,6 +1214,13 @@ describe('Directive: snapscroll', function () {
             });
             $scope.$apply(function () {
                 $scope.index = 1;
+            });
+            expect(element[0].scrollTop).toBe(50);
+            $scope.$apply(function () {
+                $scope.enabled = false;
+            });
+            $scope.$apply(function () {
+                $scope.index = 0;
             });
             expect(element[0].scrollTop).toBe(50);
         });
@@ -1682,148 +1798,188 @@ describe('Directive: snapscroll', function () {
             testPreventsBubblingUpOfMousewheelEventsIfElementIsStillScrollable(html);
         });
 
-        it('snaps down on mouseheel down', function () {
-            var html = [
-                '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '</div>'
-            ].join('');
-            testSnapsDownOnMousewheelDown(html);
+        describe('on mouseheel down', function () {
+            it('snaps down', function () {
+                var html = [
+                    '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '</div>'
+                ].join('');
+                testSnapsDownOnMousewheelDown(html);
+            });
+
+            it('does not snap down if the element is not scrollable', function () {
+                var html = [
+                    '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
+                    '</div>'
+                ].join('');
+                testDoesntSnapDownIfElementIsNotScrollable(html);
+            });
+
+            it('executes beforeSnap', function () {
+                var html = [
+                    '<div snapscroll="" snap-index="index" before-snap="beforeSnap(index)" style="height: 50px; overflow: auto">',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 125px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '</div>'
+                ].join('');
+                testExecutesBeforeSnapOnMousewheelDown(html);
+            });
+
+            it('does not snap down if beforeSnap returns false', function () {
+                var html = [
+                    '<div snapscroll="" snap-index="index" before-snap="beforeSnap(index)" style="height: 50px; overflow: auto">',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '</div>'
+                ].join('');
+                testDoesNotSnapDownIfBeforeSnapReturnsFalseOnMousewheelDown(html);
+            });
+
+            it('snaps to a different snapIndex if beforeSnap returns a number', function () {
+                var html = [
+                    '<div snapscroll="" snap-index="index" before-snap="beforeSnap(index)" style="height: 50px; overflow: auto">',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '</div>'
+                ].join('');
+                testSnapsToADifferentSnapIndexIfBeforeSnapReturnsNumberOnMousewheelDown(html);
+            });
+
+            it('shows the rest of a snap for a bigger-height child', function () {
+                var html = [
+                    '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 125px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '</div>'
+                ].join('');
+                testShowsRestOfBigSnapOnMousewheelDown(html);
+            });
+
+            it('doens\'t snap downif the element is already scrolled to the end', function () {
+                var html = [
+                    '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '</div>'
+                ].join('');
+                testDoesntSnapDownOnNewDownMousewheelIfAlreadyScrolledToBottom(html);
+            });
+
+            it('does not snap down if a bigger-height child is scrolled to the end', function () {
+                var html = [
+                    '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 125px"></div>',
+                    '</div>'
+                ].join('');
+                testDoesntSnapDownIfBiggerHeightChildIsScrolledToTheEnd(html);
+            });
         });
 
-        it('snaps up on mouseheel up', function () {
-            var html = [
-                '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '</div>'
-            ].join('');
-            testSnapsUpOnMousewheelUp(html);
-        });
+        describe('on mouseheel down', function () {
+            it('snaps up', function () {
+                var html = [
+                    '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '</div>'
+                ].join('');
+                testSnapsUpOnMousewheelUp(html);
+            });
 
-        it('executes beforeSnap on mouseheel down', function () {
-            var html = [
-                '<div snapscroll="" snap-index="index" before-snap="beforeSnap(index)" style="height: 50px; overflow: auto">',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 125px"></div>',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '</div>'
-            ].join('');
-            testExecutesBeforeSnapOnMousewheelDown(html);
-        });
+            it('does not snap up if the element is not scrollable', function () {
+                var html = [
+                    '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
+                    '</div>'
+                ].join('');
+                testDoesntSnapUpIfElementIsNotScrollable(html);
+            });
 
-        it('executes beforeSnap on mouseheel up', function () {
-            var html = [
-                '<div snapscroll="" snap-index="index" before-snap="beforeSnap(index)" style="height: 50px; overflow: auto">',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 125px"></div>',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '</div>'
-            ].join('');
-            testExecutesBeforeSnapOnMousewheelUp(html);
-        });
+            it('executes beforeSnap', function () {
+                var html = [
+                    '<div snapscroll="" snap-index="index" before-snap="beforeSnap(index)" style="height: 50px; overflow: auto">',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 125px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '</div>'
+                ].join('');
+                testExecutesBeforeSnapOnMousewheelUp(html);
+            });
 
-        it('does not snap down if beforeSnap returns false on mouseheel down', function () {
-            var html = [
-                '<div snapscroll="" snap-index="index" before-snap="beforeSnap(index)" style="height: 50px; overflow: auto">',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '</div>'
-            ].join('');
-            testDoesNotSnapDownIfBeforeSnapReturnsFalseOnMousewheelDown(html);
-        });
+            it('does not snap up if beforeSnap returns false', function () {
+                var html = [
+                    '<div snapscroll="" snap-index="index" before-snap="beforeSnap(index)" style="height: 50px; overflow: auto">',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '</div>'
+                ].join('');
+                testDoesNotSnapUpIfBeforeSnapReturnsFalseOnMousewheelUp(html);
+            });
 
-        it('does not snap up if beforeSnap returns false on mouseheel up', function () {
-            var html = [
-                '<div snapscroll="" snap-index="index" before-snap="beforeSnap(index)" style="height: 50px; overflow: auto">',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '</div>'
-            ].join('');
-            testDoesNotSnapUpIfBeforeSnapReturnsFalseOnMousewheelUp(html);
-        });
+            it('snaps to a different snapIndex if beforeSnap returns a number', function () {
+                var html = [
+                    '<div snapscroll="" snap-index="index" before-snap="beforeSnap(index)" style="height: 50px; overflow: auto">',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '</div>'
+                ].join('');
+                testSnapsToADifferentSnapIndexIfBeforeSnapReturnsNumberOnMousewheelUp(html);
+            });
 
-        it('snaps to a different snapIndex if beforeSnap returns a number on mouseheel down', function () {
-            var html = [
-                '<div snapscroll="" snap-index="index" before-snap="beforeSnap(index)" style="height: 50px; overflow: auto">',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '</div>'
-            ].join('');
-            testSnapsToADifferentSnapIndexIfBeforeSnapReturnsNumberOnMousewheelDown(html);
-        });
+            it('shows the rest of a snap instead of snapping up if it\'s greater than the snapHeight', function () {
+                var html = [
+                    '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 125px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '</div>'
+                ].join('');
+                testShowsRestOfBigSnapOnMousewheelUp(html);
+            });
 
-        it('snaps to a different snapIndex if beforeSnap returns a number on mouseheel up', function () {
-            var html = [
-                '<div snapscroll="" snap-index="index" before-snap="beforeSnap(index)" style="height: 50px; overflow: auto">',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '</div>'
-            ].join('');
-            testSnapsToADifferentSnapIndexIfBeforeSnapReturnsNumberOnMousewheelUp(html);
-        });
+            it('doens\'t snap up if the element\'s scrollTop is 0', function () {
+                var html = [
+                    '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '</div>'
+                ].join('');
+                testDoesntSnapUpOnNewDownMousewheelIfAlreadyScrolltopIsZero(html);
+            });
 
-        it('shows the rest of a snap instead of snapping down if it\'s greater than the snapHeight on mouseheel down', function () {
-            var html = [
-                '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 125px"></div>',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '</div>'
-            ].join('');
-            testShowsRestOfBigSnapOnMousewheelDown(html);
-        });
-
-        it('shows the rest of a snap instead of snapping up if it\'s greater than the snapHeight on mouseheel up', function () {
-            var html = [
-                '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 125px"></div>',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '</div>'
-            ].join('');
-            testShowsRestOfBigSnapOnMousewheelUp(html);
-        });
-
-        it('doens\'t snap down on a new down-mousewheel event if the element is already scrolled to the end', function () {
-            var html = [
-                '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '</div>'
-            ].join('');
-            testDoesntSnapDownOnNewDownMousewheelIfAlreadyScrolledToBottom(html);
-        });
-
-        it('doens\'t snap up on a new up-mousewheel event if the element\'s scrollTop is 0', function () {
-            var html = [
-                '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '</div>'
-            ].join('');
-            testDoesntSnapUpOnNewDownMousewheelIfAlreadyScrolltopIsZero(html);
+            it('does not snap up if a bigger-height child is scrolled to the beginning', function () {
+                var html = [
+                    '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
+                    '<div style="height: 125px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '</div>'
+                ].join('');
+                testDoesntSnapDownIfBiggerHeightChildIsScrolledToTheBeginning(html);
+            });
         });
 
         it('stops listening to mousewheel events when scope is destroyed', function () {
@@ -2278,14 +2434,12 @@ describe('Directive: snapscroll', function () {
 
     // different test suite for animations
     describe('as an attribute', function () {
-        var snapDurationMock,
-            snapEasingMock;
+        var snapDurationMock;
 
         beforeEach(inject(function ($q) {
             var deferred = $q.defer();
 
             snapDurationMock = undefined;
-            snapEasingMock = undefined;
 
             scrollMock.to = jasmine.createSpy('scroll.to').and.callFake(function (element, top, duration, easing) {
                 if (angular.isDefined(duration)) {
@@ -2295,9 +2449,6 @@ describe('Directive: snapscroll', function () {
                 }
                 if (angular.isFunction(easing)) {
                     easing.call();
-                    snapEasingMock = 1;
-                } else {
-                    snapEasingMock = undefined;
                 }
                 element[0].scrollTop = top;
                 deferred.resolve();
@@ -2482,7 +2633,6 @@ describe('Directive: snapscroll', function () {
             expect(snapDurationMock).toBe(defaultSnapscrollSnapDuration);
         }));
 
-        // TODO: is this functionality really necessary??
         it('allows setting the snapAnimation easing (snapEasing)', function () {
             var html = [
                 '<div snapscroll="" snap-index="index" snap-easing="easing" style="height: 50px; overflow: auto">',
@@ -2491,30 +2641,15 @@ describe('Directive: snapscroll', function () {
                 '<div style="height: 50px"></div>',
                 '</div>'
             ].join('');
-            $scope.easing = function () {};
+            var spy = jasmine.createSpy('easing');
+            $scope.easing = spy;
             compileElement(html, true);
             $scope.index = 1;
             $scope.$apply();
-            expect(snapEasingMock).toBe(1);
+            expect(spy).toHaveBeenCalled();
         });
 
-        it('uses whichever snapEasing is provided', function () {
-            var easing = jasmine.createSpy('easing');
-            var html = [
-                '<div snapscroll="" snap-index="index" snap-easing="easing" style="height: 50px; overflow: auto">',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '<div style="height: 50px"></div>',
-                '</div>'
-            ].join('');
-            $scope.easing = easing;
-            compileElement(html, true);
-            $scope.index = 1;
-            $scope.$apply();
-            expect(easing).toHaveBeenCalled();
-        });
-
-        it('uses the defaultSnapscrollScrollEasing if set', function () {
+        it('uses the defaultSnapscrollScrollEasing as the easing if\'s set to a function', function () {
             var html = [
                 '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
                 '<div style="height: 50px"></div>',

--- a/test/spec/directives/snapscroll.js
+++ b/test/spec/directives/snapscroll.js
@@ -2036,6 +2036,26 @@ describe('Directive: snapscroll', function () {
             testUsesTheOriginalBrowserMousewheelEvents(html);
         });
 
+        describe('with smaller-height elements', function () {
+            it('does not try to scroll to set scrollTop to a value greater than the max available scrollHeight', inject(function (defaultSnapscrollSnapDuration, defaultSnapscrollScrollEasing) {
+                var html = [
+                    '<div snapscroll="" snap-index="index" style="height: 50px; overflow: auto">',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 50px"></div>',
+                    '<div style="height: 25px"></div>',
+                    '</div>'
+                ].join('');
+                $scope.index = 0;
+                var element = compileElement(html, true);
+                scrollMock.to.calls.reset(); // reset calls from initial snap
+                $scope.$apply(function () {
+                    $scope.index = 2;
+                });
+                expect(element[0].scrollTop).toBe(75);
+                expect(scrollMock.to).toHaveBeenCalledWith(element, 75, defaultSnapscrollSnapDuration, defaultSnapscrollScrollEasing);
+            }));
+        });
+
         // new test suite for tests to do with manual scrolling
         describe('', function () {
             var $timeout;


### PR DESCRIPTION
Fixes #26 
- [x] add tests
- [x] add implementation
- [x] fix broken tests 
- [x] ensure beforeSnap and afterSnap logic is maintained
- [x] ensure snapping-after-manual-scroll behaviour snaps to the correct `scrollTop` when a child element has a bigger height
- [x] ensure snap-from-current-scrolltop logic is maintained 
- [x] ~~use a class `Snapscroll` to maintain state instead of polluting the scope. Will also make it easier to unit-test.~~ won't do. I'd forgotten that angular only exposes what's in the scope binding. as for the tests, they are a mess but they do their job. will think about refactoring later.
- [x] use an object to track changes to `snapIndex` and `innerSnapIndex` instead of two separate values ~~turned out to be more messy than the current solution. `snapIndex` changes from outside would need to update the object, whereas `innerSnapIndex` and `snapIndex` changes from inside would need to also update `snapIndex`~~ 19b1bcb. 
- [x] verify behaviour of smaller-height children
- [x] update documentation
- [x] update demo
